### PR TITLE
Fixes runtime exceptions in RobotMap and Vision.

### DIFF
--- a/src/main/java/frc/robot/RobotMap.java
+++ b/src/main/java/frc/robot/RobotMap.java
@@ -11,9 +11,7 @@ import java.util.List;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-/** Add your docs here. */
-public class RobotMap {
-  /*
+/*
   JSON RobotMap config format:
   [
     {
@@ -21,17 +19,24 @@ public class RobotMap {
       "Value": NEW_VALUE_OF_CORRESPONDING_TYPE
     }
   ]
-  */
+*/
 
-  class RobotMapConfigValue {
-    String varName = null;
-    Object value = null;
-    RobotMapConfigValue(String varName, Object value) {
+class RobotMapConfigValue {
+  String varName = null;
+  Object value = null;
+
+  public void setVarName(String varName) {
       this.varName = varName;
-      this.value = value;
-    }
   }
-  
+
+  public void setValue(Object value) {
+      this.value = value;
+  }
+}
+
+/** Add your docs here. */
+public class RobotMap {
+
   public static void init()
   {
     try {
@@ -50,8 +55,14 @@ public class RobotMap {
 
         for (int i=0; i < changedValues.size(); i++) {
           RobotMapConfigValue value = changedValues.get(i);
-          Field field = RobotMap.class.getField(value.varName);
-          field.set(null, value.value);
+          try {
+            Field field = RobotMap.class.getField(value.varName);
+            field.set(null, value.value);
+            System.out.println("Configuring " + value.varName + " to " + value.value);
+          }
+          catch (java.lang.NoSuchFieldException x) {
+            System.out.println("No RobotMap field named " + value.varName);
+          }
         }
       }  
       else

--- a/src/main/java/frc/robot/utils/vision/VisionSystem.java
+++ b/src/main/java/frc/robot/utils/vision/VisionSystem.java
@@ -39,7 +39,7 @@ public class VisionSystem {
     }
 
     public PhotonPipelineResult getLatestResult() {
-        if(m_camera != null){
+        if(m_camera != null && !m_camera.getAllUnreadResults().isEmpty()){
             return m_camera.getAllUnreadResults().get(0);
         } else {
             return new PhotonPipelineResult();


### PR DESCRIPTION
In RobotMap.init(), jackson didn't work with RobotMapConfigValue as an inner class, or its non-default constructor. Moved it outside of RobotMap and added property setters. The default constructor is implied.

VisionSystem.getLatestResult() threw an exception if there were no results to get. Now it checks for that.